### PR TITLE
mention that reponse.urljoin uses <base> tag to resolve relative URLs

### DIFF
--- a/docs/rules/scp03.rst
+++ b/docs/rules/scp03.rst
@@ -14,8 +14,11 @@ Finds usage of :func:`~urllib.parse.urljoin` that can be replaced with
 Why is this bad?
 ================
 
-:meth:`Response.urljoin() <scrapy.http.Response.urljoin>` is more readable.
+:meth:`Response.urljoin() <scrapy.http.Response.urljoin>`
 
+* uses HTML ``<base>`` tag to properly resolve relative URLs,
+* doesn't require an extra import, and
+* is more readable.
 
 Example
 =======

--- a/docs/rules/scp03.rst
+++ b/docs/rules/scp03.rst
@@ -16,7 +16,7 @@ Why is this bad?
 
 :meth:`Response.urljoin() <scrapy.http.Response.urljoin>`
 
-* uses HTML ``<base>`` tag to properly resolve relative URLs,
+* uses the HTML ``<base>`` tag to properly resolve relative URLs,
 * doesn't require an extra import, and
 * is more readable.
 


### PR DESCRIPTION
It's a bit confusing, because if you follow [Response.urljoin](https://docs.scrapy.org/en/latest/topics/request-response.html#scrapy.http.Response.urljoin) docs, it'd tell response.urljoin is just a shortcut to urljoin, which is technically correct. 

But in practice it's [TextResponse.urljoin](https://docs.scrapy.org/en/latest/topics/request-response.html#scrapy.http.TextResponse.urljoin) what matters - this is what is going to be used in most cases when user writes `response.urljoin`. In this case `<base>` tags are also handled, which is quite important.