### PR TITLE
Flag placeholder Zyte API keys

### DIFF
--- a/scrapy_lint/finders/settings/values.py
+++ b/scrapy_lint/finders/settings/values.py
@@ -413,6 +413,20 @@ def check_user_agent(node: expr, **_) -> Generator[Issue]:
         yield issue
 
 
+INVALID_ZYTE_API_KEY_VALUES = {"", "your_api_key"}
+
+
+def check_zyte_api_key(node: expr, **_) -> Generator[Issue]:
+    if not isinstance(node, Constant) or not isinstance(node.value, str):
+        return
+    if node.value.strip().lower() in INVALID_ZYTE_API_KEY_VALUES:
+        yield Issue(
+            INVALID_SETTING_VALUE,
+            Pos.from_node(node),
+            "must not be empty or a placeholder",
+        )
+
+
 class ValueChecker(Protocol):  # pylint: disable=too-few-public-methods
     def __call__(self, node: expr, *, context: Context) -> Generator[Issue]: ...
 
@@ -422,4 +436,5 @@ VALUE_CHECKERS: dict[str, ValueChecker] = {
     "FEED_URI": check_feed_uri,
     "FEEDS": check_feeds,
     "USER_AGENT": check_user_agent,
+    "ZYTE_API_KEY": check_zyte_api_key,
 }

--- a/tests/test_setting_values.py
+++ b/tests/test_setting_values.py
@@ -747,6 +747,15 @@ CASES: Cases = (
                             ("SCP36 invalid setting value", "USER_AGENT", value, 0)
                             for value in ("5559292",)
                         ),
+                        *(
+                            (
+                                "SCP36 invalid setting value: must not be empty or a placeholder",
+                                "ZYTE_API_KEY",
+                                value,
+                                0,
+                            )
+                            for value in ("''", "'YOUR_API_KEY'", "'your_api_key'")
+                        ),
                         # SCP42 unneeded path string
                         ("SCP42 unneeded path string", "FEED_URI", "'output.jsonl'", 0),
                         (


### PR DESCRIPTION
Fixes #83.

This extends SCP36 to flag `ZYTE_API_KEY` values that are empty or obvious placeholders like `YOUR_API_KEY`.

I kept the check intentionally narrow so it does not try to validate the full key format or reject dynamic values.