### PR TITLE
Detect feed URIs whose authority does not parse, e.g. unencoded credentials

### DIFF
--- a/docs/rules/scp36.rst
+++ b/docs/rules/scp36.rst
@@ -33,3 +33,12 @@ valid for the setting, and assign a valid value:
     :caption: ``settings.py``
 
     CONCURRENT_REQUESTS_PER_DOMAIN = 1
+
+Feed URIs are a common source of this issue, because credentials must be
+percent-encoded, e.g. with :func:`urllib.parse.quote`, for the rest of the URI
+to be parsed as intended:
+
+.. code-block:: python
+    :caption: ``settings.py``
+
+    FEEDS = {"ftp://jane:pa%2Fss@ftp.example.com/output.json": {"format": "json"}}

--- a/scrapy_lint/finders/settings/types.py
+++ b/scrapy_lint/finders/settings/types.py
@@ -6,6 +6,7 @@ from ast import Call, Constant, Dict, Lambda, List, Set, Tuple, expr
 from collections.abc import Generator, Iterable
 from functools import partial
 from typing import TYPE_CHECKING, Protocol
+from urllib.parse import urlsplit
 
 from packaging.version import Version
 
@@ -40,6 +41,19 @@ def check_import_path_need(
 
 def has_feed_uri_params(value: str) -> bool:
     return bool(re.search(r"%\([^)]+\)[sdifouxXeEgGcr]", value))
+
+
+def has_valid_authority(uri: str) -> bool:
+    try:
+        parts = urlsplit(uri)
+        if not has_feed_uri_params(parts.netloc):
+            # A character that credentials must percent-encode, such as a
+            # slash, cuts the authority short, leaving part of the credentials
+            # where the port belongs. urlsplit only parses the port on access.
+            _ = parts.port
+    except ValueError:
+        return False
+    return True
 
 
 def is_import_path(value: str, **_) -> bool:

--- a/scrapy_lint/finders/settings/values.py
+++ b/scrapy_lint/finders/settings/values.py
@@ -11,6 +11,7 @@ from scrapy_lint.data.settings import FEEDS_KEY_VERSION_ADDED
 from scrapy_lint.finders.settings.types import (
     check_import_path_need,
     has_feed_uri_params,
+    has_valid_authority,
     is_import_path,
     is_path_obj,
 )
@@ -122,6 +123,9 @@ def check_feed_uri(
             and not has_feed_uri_params(path)
         ):
             yield unneeded_str
+        if not has_valid_authority(node.value):
+            detail = "invalid URI, e.g. credentials not percent-encoded"
+            yield Issue(INVALID_SETTING_VALUE, pos, detail)
 
 
 def check_feed_class_list(

--- a/tests/test_setting_values.py
+++ b/tests/test_setting_values.py
@@ -156,6 +156,13 @@ CASES: Cases = (
                         ("FEEDS", "{}"),
                         ("FEEDS", "{a: b}"),
                         ("FEEDS", "{a: {b: c}}"),
+                        ("FEEDS", '{"ftp://user:p%40ss@example.com:21/f.json": {}}'),
+                        ("FEEDS", '{"ftp://[::1]:21/f.json": {}}'),
+                        # A URI param can also stand for the port.
+                        ("FEEDS", '{"ftp://example.com:%(port)s/f.json": {}}'),
+                        # Outside the authority, "@" is part of the path.
+                        ("FEEDS", '{"s3://bucket/jane.doe@example.com.csv": {}}'),
+                        ("FEED_URI", '"ftp://user:p%40ss@example.com/f.json"'),
                         ("JOBDIR", "foo"),
                         ("JOBDIR", "foo()"),
                         ("JOBDIR", '"/tmp/foo"'),
@@ -486,6 +493,21 @@ CASES: Cases = (
                                 *(
                                     (
                                         "FEEDS",
+                                        f'{{"{uri}": {{}}}}',
+                                        1,
+                                        "invalid URI, e.g. credentials not "
+                                        "percent-encoded",
+                                    )
+                                    for uri in (
+                                        "ftp://user:pa/ss@example.com/f.json",
+                                        "ftp://user:pa?ss@example.com/f.json",
+                                        "ftp://user:pa#ss@example.com/f.json",
+                                        "s3://key:sec/ret@bucket/f.csv",
+                                    )
+                                ),
+                                *(
+                                    (
+                                        "FEEDS",
                                         value,
                                         4,
                                         "FEEDS dict values must be dicts of "
@@ -662,6 +684,12 @@ CASES: Cases = (
                                     24,
                                     "postprocessing[0] ('foo') does not look "
                                     "like a valid import path",
+                                ),
+                                (
+                                    "FEED_URI",
+                                    '"ftp://user:pa/ss@example.com/f.json"',
+                                    0,
+                                    "invalid URI, e.g. credentials not percent-encoded",
                                 ),
                                 (
                                     "PERIODIC_LOG_DELTA",


### PR DESCRIPTION
Resolve https://github.com/scrapy/scrapy-lint/issues/90